### PR TITLE
Enforce SuperBLT-compatible release archives

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Validate release metadata
         run: python scripts/validate_release.py
+
+      - name: Build SuperBLT-compatible release archive
+        run: python scripts/build_release.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable changes to Silent DLC Unlocker are documented here. The project follows 
 
 ## Unreleased
 
+- Added a deterministic SuperBLT-compatible release builder and CI archive validation.
+
 ## 1.5.0 - 2026-07-15
 
 - Added a new shushing-dog project logo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,10 @@ The repository's GitHub Actions workflow compiles every Lua file and checks the 
 find SilentDLCUnlocker -name '*.lua' -print0 | xargs -0 -n1 luac5.1 -p
 lua5.1 tests/verifier_spec.lua
 python scripts/validate_release.py
+python scripts/build_release.py
 ```
+
+Always publish the ZIP produced by `scripts/build_release.py`. SuperBLT reads raw ZIP local headers and requires forward-slash entry paths; archives produced by PowerShell `Compress-Archive` can download successfully but fail during extraction.
 
 PAYDAY 2 APIs are only available inside the game, so syntax checks cannot replace a manual smoke test. At minimum, verify that the mod loads, its options menu opens, settings persist after restart, and the three modes handle one known risky item correctly.
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -1,0 +1,93 @@
+import argparse
+import struct
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MOD_DIR = ROOT / "SilentDLCUnlocker"
+LOCAL_HEADER = b"PK\x03\x04"
+
+
+def local_header_names(path: Path):
+    names = []
+    with path.open("rb") as archive:
+        while archive.read(4) == LOCAL_HEADER:
+            header = archive.read(26)
+            if len(header) != 26:
+                raise ValueError("truncated ZIP local header")
+
+            fields = struct.unpack("<HHHHHIIIHH", header)
+            flags = fields[1]
+            compression = fields[2]
+            compressed_size = fields[6]
+            name_length = fields[8]
+            extra_length = fields[9]
+            name = archive.read(name_length).decode("utf-8")
+
+            if flags & 0x08:
+                raise ValueError(f"data descriptors are unsupported by SuperBLT: {name}")
+            if compression not in (0, 8):
+                raise ValueError(f"unsupported compression method {compression}: {name}")
+
+            names.append(name)
+            archive.seek(extra_length + compressed_size, 1)
+
+    return names
+
+
+def verify_archive(path: Path) -> None:
+    with zipfile.ZipFile(path) as archive:
+        if archive.testzip() is not None:
+            raise ValueError("ZIP CRC validation failed")
+        central_names = archive.namelist()
+
+    local_names = local_header_names(path)
+    if not local_names or local_names != central_names:
+        raise ValueError("ZIP local headers do not match the central directory")
+
+    for name in local_names:
+        if "\\" in name:
+            raise ValueError(f"SuperBLT-incompatible backslash in ZIP path: {name}")
+        if not name.startswith("SilentDLCUnlocker/"):
+            raise ValueError(f"file is outside SilentDLCUnlocker/: {name}")
+
+
+def build_archive(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+        for source in sorted(MOD_DIR.rglob("*")):
+            if not source.is_file():
+                continue
+
+            name = source.relative_to(ROOT).as_posix()
+            info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+            info.create_system = 0
+            info.external_attr = 0x20
+            archive.writestr(
+                info,
+                source.read_bytes(),
+                compress_type=zipfile.ZIP_DEFLATED,
+                compresslevel=9,
+            )
+
+    verify_archive(path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a SuperBLT-compatible release ZIP")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=ROOT / "SilentDLCUnlocker.zip",
+        help="output ZIP path",
+    )
+    args = parser.parse_args()
+
+    output = args.output.resolve()
+    build_archive(output)
+    print(f"Built and verified {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- adds a deterministic Python release builder that writes forward-slash ZIP entry paths
- validates raw local headers using the same constraints as SuperBLT's extractor
- rejects backslashes, data descriptors, unsupported compression, CRC errors, and files outside the mod folder
- runs the archive build in GitHub Actions and documents the required release command

## Root cause

PowerShell `Compress-Archive` stored Windows backslashes in local ZIP headers. SuperBLT reads those headers directly and failed to create the nested extraction directory, even though standard ZIP tools displayed normalized paths.

## Validation

- repeated builds produced identical SHA-256 hashes
- raw local-header validation passed for all nine runtime files
- verifier parity tests passed
- release metadata and YAML validation passed